### PR TITLE
fix shellcheck warnings, use XDG desktop variables, don't hardcode discord version

### DIFF
--- a/discocss
+++ b/discocss
@@ -1,13 +1,13 @@
 #!/bin/sh
 
-confdir="$HOME/.config/discocss"
+confdir="${XDG_CONFIG_HOME:=$HOME/.config}/discocss"
 preloadFile="$confdir/preload.js"
 cssFile="$confdir/custom.css"
 
 mkdir -p "$confdir"
 
-if [ ! -f $preloadFile ]; then
-    cat <<EOF >$preloadFile
+if [ ! -f "$preloadFile" ]; then
+    cat <<EOF > "$preloadFile"
 (() => {
   const css = require("fs").readFileSync("$cssFile");
 
@@ -26,8 +26,7 @@ EOF
     ln -s "$preloadFile" /tmp/discocss-preload.js
 fi
 
-# TODO autodetect this path
 sed -i 's|  // App preload script, used to provide a replacement native API now that|try { require\(`/tmp/discocss-preload.js`) } catch \(e\) {console.error\(e\);} |' \
-    ~/.config/discord/0.0.11/modules/discord_desktop_core/core.asar
+    "$XDG_CONFIG_HOME"/discord/*/modules/discord_desktop_core/core.asar
 
 Discord


### PR DESCRIPTION
If discord keeps old versions, this will run the sed command on them too. If it doesn't, it'll only run on the latest.