### PR TITLE
add .desktop file if alias is true

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,9 +27,14 @@ runCommand "discocss"
   buildInputs = [ makeWrapper ];
   preferLocalBuild = true;
 } ''
-  mkdir -p $out/bin
+  mkdir -p $out/{bin,share}
 
-  ${lib.optionalString discordAlias "ln -s $out/bin/discocss $out/bin/Discord"}
+  ${lib.optionalString discordAlias ''
+    ln -s $out/bin/discocss $out/bin/Discord
+
+    ln -s ${discord}/share/* $out/share/
+  ''}
+
 
   makeWrapper ${unwrapped}/bin/discocss $out/bin/discocss \
     --set DISCOCSS_DISCORD_BIN ${discord}/bin/Discord


### PR DESCRIPTION
I was annoyed at not having discord show up anymore in my launcher, so I decided to extend the use of `discordAlias`.

Tested on my nixos config, it now pops up fine and launches Discord.