### PR TITLE
 Unique symlink name inside /tmp

### DIFF
--- a/discocss
+++ b/discocss
@@ -4,6 +4,33 @@ confdir="${XDG_CONFIG_HOME:=$HOME/.config}/discocss"
 preloadFile="$confdir/preload.js"
 cssFile="$confdir/custom.css"
 
+# Generate random fixed-width ID using $1 param as seed.
+gen_id() {
+	WIDTH=7
+
+	ASCII=""
+	SEED=""
+	# Decode string into ascii values, seed must be numerical
+	for i in $(seq ${#1})
+	do 
+		LETTER=$(echo "$1" | cut -c "$i")
+		ASCII=$(printf "%d" "'$LETTER")
+		SEED="${SEED}${ASCII}"
+	done
+
+	SEED=$((SEED % 4294967295))
+
+	ID=$(awk -v s=$SEED 'BEGIN { srand(s); print int(rand()*32768) }' /dev/null)
+	while [ ${#ID} -lt $WIDTH ]
+	do
+		ID="$(awk -v s="$ID" 'BEGIN { srand(s); print int(rand()*32768) }' /dev/null)${ID}"
+	done
+	ID=$(echo "$ID" | cut -c "-${WIDTH}")
+}
+gen_id "$USER"
+
+preloadLink="/tmp/discocss-${ID}.js"
+
 mkdir -p "$confdir"
 
 touch "$cssFile"
@@ -60,7 +87,7 @@ module.exports.mo = (options) => {
 };
 EOF
 
-ln -f -s "$preloadFile" /tmp/discocss-preload.js
+ln -f -s "$preloadFile" "$preloadLink"
 
 if [ "$(uname)" = "Darwin" ]; then
   sed_options='-i ""'
@@ -70,8 +97,8 @@ else
   core_asar="$(echo "$XDG_CONFIG_HOME/discord/"*"/modules/discord_desktop_core/core.asar")"
 fi
 
-app_preload_replace='s|  // App preload script, used to provide a replacement native API now that|try {require\(`/tmp/discocss-preload.js`)()} catch \(e\) {console.error\(e\);} |'
-launch_main_app_replace='s|// launch main app window; could be called multiple times for various reasons| const dp = require(`/tmp/discocss-preload.js`);                             |'
+app_preload_replace='s|  // App preload script, used to provide a replacement native API now that|try {require\(`'"$preloadLink"'`)()} catch \(e\) {console.error\(e\);} |'
+launch_main_app_replace='s|// launch main app window; could be called multiple times for various reasons| const dp = require(`'"$preloadLink"'`);                             |'
 frame_true_replace='s|    mainWindowOptions.frame = true;|}dp.mo(mainWindowOptions);{        |'
 causing_the_window_replace='s|// causing the window to be too small on a larger secondary display| dp.mw(mainWindow);                                                |'
 LC_ALL=C sed $sed_options "$app_preload_replace; $launch_main_app_replace; $frame_true_replace; $causing_the_window_replace" \


### PR DESCRIPTION
# Summary
This PR addressed #20.

The method to generate the random ID's is to transform the $USER variable into a numerical seed and then use awk `srand(seed)` and `rand()` to generate the 7 character long ID.

The solution is a little bit over-engineered I think, but it works perfectly!

I will explain my reasoning but feel free to change anything.

# Rationale
I put the procedure inside a `gen_id()` function only for the reason that I thought it was orderly.

Didn't want to add any dependencies so that's why I went with the current approach. The hashing commands I found depnded on Perl, and even the `$RANDOM` variable apparently wasn't POSIX compliant. That's why I ended up using `awk` for the RNG.

The reason the string is decoded into ASCII values is because the seed must be numerical, if you try to pass a string rand() will always return the same values.

The `SEED=$((SEED % 4294967295))` is there because `srand()` takes in an `unsigned int` and 4294967295 is the max value of one.

The while loop where I'm checking `while [ ${#ID} -lt $WIDTH ]` is there because even if I multiplied `rand()` by a large enough number, I think there's always a chance it returns really low numbers so this while loop *guarantees* that ID will reach at least 7 characters long. Could've also added padding to the string but I think to keep generating more random numbers generates more unique numbers than adding padding does?

The reason I multiply `rand()*32768` in specific is simply because that's what they multiply it by in the [shellcheck example for RNG](https://www.shellcheck.net/wiki/SC3028). I think it could be literally any number and it wouldn't matter anyways.

# Shellcheck

I made sure the commit didn't add any shellcheck warnings or anything, this is my `shellcheck` output:
```
λ [master] >>> shellcheck discocss

In discocss line 104:
LC_ALL=C sed $sed_options "$app_preload_replace; $launch_main_app_replace; $frame_true_replace; $causing_the_window_replace" \
             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
LC_ALL=C sed "$sed_options" "$app_preload_replace; $launch_main_app_replace; $frame_true_replace; $causing_the_window_replace" \

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```