### PR TITLE
Add --injectOnly

### DIFF
--- a/discocss
+++ b/discocss
@@ -77,11 +77,13 @@ causing_the_window_replace='s|// causing the window to be too small on a larger 
 LC_ALL=C sed $sed_options "$app_preload_replace; $launch_main_app_replace; $frame_true_replace; $causing_the_window_replace" \
   "$core_asar"
 
-discordBin="$DISCOCSS_DISCORD_BIN"
-if [ "$discordBin" ]; then
-  unset DISCOCSS_DISCORD_BIN
-  exec "$discordBin"
-else
-  command -v discord && exec discord
-  command -v Discord && exec Discord
+if [[ "$*" != *"--injectOnly"* ]]; then
+  discordBin="$DISCOCSS_DISCORD_BIN"
+  if [ "$discordBin" ]; then
+    unset DISCOCSS_DISCORD_BIN
+    exec "$discordBin"
+  else
+    command -v discord && exec discord
+    command -v Discord && exec Discord
+  fi
 fi


### PR DESCRIPTION
Adds a parameter that tells discocss to only inject the CSS and not launch Discord. This can be useful when automating the generation of dotfiles using e.g. Nix.