### PR TITLE
Remove AUR package from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ git clone https://github.com/mlvzk/discocss
 cp discocss/discocss /usr/bin # or any other directory in your $PATH
 ```
 
-If you use Arch Linux, there's an unofficial AUR package available: [discocss-git](https://aur.archlinux.org/packages/discocss-git/)
-
 # Usage
 
 Put your css in `~/.config/discocss/custom.css`


### PR DESCRIPTION
I no longer maintain the AUR package for discocss, as I no longer use Arch Linux. Because of this, it would be best to not recommend users to install from the AUR since the package may potentially break in future releases.